### PR TITLE
timefilter.py now compatible with Astropy v2.0.2

### DIFF
--- a/lib/costools/timefilter.py
+++ b/lib/costools/timefilter.py
@@ -44,7 +44,6 @@ import os
 import sys
 import numpy as np
 import astropy.io.fits as fits
-from astropy.table import Table
 from stsci.tools import parseinput, teal
 from calcos import ccos
 from calcos import calcosparam, cosutil


### PR DESCRIPTION
Changes to Astropy caused timefilter.py to produce a host of errors. Now I have made it compatible with Astropy v2.0.2 and it runs fine.  