### PR TITLE
1.2.2 -> 1.2.3: No code changes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = costools
-version = 1.2.2.dev
+version = 1.2.3
 author = Warren Hack, Nadezhda Dencheva, Phil Hodge, Robert Jedrzejewski
 author-email = help@stsci.edu
 home-page = https://github.com/spacetelescope/costools


### PR DESCRIPTION
* Remove `.dev` suffix from version

The previous release on PyPi was `1.2` and requires `pyfits`. This may have generated tickets in the past. 

Uploading the current tag `1.2.2` (really `1.2.2.dev0`) won't work because PyPi will mark it as a pre-release (requiring `pip install --pre costools` rather than `pip install costools`).