### PR TITLE
use canonical filename of RTD configuration, enable `nitpicky` mode, and build with Python 3.13 and Sphinx 9

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,9 +18,16 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: mambaforge-4.10
+
+conda:
+  environment: docs/rtd_environment.yaml
+
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
   install:
     - method: pip
       path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,4 @@
-# .readthedocs.yml
+# .readthedocs.yaml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
@@ -7,7 +7,9 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
+  builder: html
   configuration: docs/source/conf.py
+  fail_on_warning: true
 
 # Build documentation with MkDocs
 #mkdocs:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 sphinx:
   builder: html
   configuration: docs/source/conf.py
-  fail_on_warning: true
+  fail_on_warning: false
 
 # Build documentation with MkDocs
 #mkdocs:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,9 +19,9 @@ sphinx:
 formats: all
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: mambaforge-4.10
+    python: mambaforge-latest
 
 conda:
   environment: docs/rtd_environment.yaml

--- a/costools/timefilter.py
+++ b/costools/timefilter.py
@@ -224,7 +224,7 @@ def toRect(longitude, latitude):
         latitude in degrees.
 
     Returns
-    --------
+    -------
     array_like
         Unit vector in rectangular coordinates.
     """

--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -1,0 +1,9 @@
+name: rtd311
+channels:
+ - conda-forge
+ - defaults
+dependencies:
+ - python=3.11
+ - pip
+ - graphviz
+ - sphinx_rtd_theme>1.2.0

--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -1,9 +1,6 @@
-name: rtd311
 channels:
  - conda-forge
- - defaults
 dependencies:
- - python=3.11
+ - python=3.13
  - pip
  - graphviz
- - sphinx_rtd_theme>1.2.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -208,3 +208,6 @@ latex_documents = [
 
 # If false, no module index is generated.
 #latex_use_modindex = True
+
+# Enable nitpicky mode - which ensures that all references in the docs resolve.
+nitpicky = True

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         'docs': [
             'sphinx',
             'numpydoc',
+            'sphinx_rtd_theme>1.2.0',
         ],
         'test': [
             'pytest',


### PR DESCRIPTION
change `.readthedocs.yml` -> `.readthedocs.yaml`, enable `nitpicky` to validate intra-doc links, and ~~enable `fail_on_warning`~~