### PR TITLE
S_REGION circle size should be RADIUS, not diameter

### DIFF
--- a/costools/add_cos_s_region.py
+++ b/costools/add_cos_s_region.py
@@ -94,7 +94,8 @@ def add_s_region(input_file, dry_run):
                     cosutil.printContinuation('in extension {} header of file {}'.format(n_ext+1, input_file))
                     continue
                 diameter = 2.5 / 3600.0
-                s_region = 'CIRCLE ICRS {0:.8f} {1:.7f} {2:.8f}'.format(ra_aper, dec_aper, diameter)
+                radius = 0.5 * diameter
+                s_region = 'CIRCLE ICRS {0:.8f} {1:.7f} {2:.8f}'.format(ra_aper, dec_aper, radius)
                 if not dry_run:
                     try:
                         existing_s_region = exthdr['S_REGION']


### PR DESCRIPTION
See, for example, [Space-Time Coordinate (STC) Metadata
Linear String Implementation](https://ivoa.net/documents/STC-S/20130917/WD-STC-S-1.0-20130917.pdf)