### PR TITLE
add code owners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# automatically requests pull request reviews for files matching the given pattern; the last match takes precendence
+
+*       @spacetelescope/costools-maintainers


### PR DESCRIPTION
the `CODEOWNERS` file defines owners of certain sections of code, and will automatically request a review from the user or team when a respective file is changed

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

I made a simple `CODEOWNERS` file with a global file pattern `*`. This is more of a convenience feature than necessary, but in the long run it might be good to have a file in the repo that defines code maintainers and lets external PRs request reviews 