### PR TITLE
remove pkg_resources

### DIFF
--- a/costools/__init__.py
+++ b/costools/__init__.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, division         # confidence high
 
-from pkg_resources import get_distribution, DistributionNotFound
+import importlib.metadata
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = importlib.metadata.version(__name__)
+except importlib.metadata.PackageNotFoundError:
     # package is not installed
     __version__ = 'UNKNOWN'
 


### PR DESCRIPTION
Closes https://github.com/spacetelescope/costools/issues/36

Replace pkg_resources with the more standard importlib.metadata.